### PR TITLE
Add API to disable watchdog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
  "atsamv71q21b",
  "cortex-m",
  "embedded-hal",
- "nb",
+ "nb 0.1.3",
 ]
 
 [[package]]
@@ -720,19 +720,28 @@ dependencies = [
 
 [[package]]
 name = "embedded-hal"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa998ce59ec9765d15216393af37a58961ddcefb14c753b4816ba2191d865fcb"
+checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
 dependencies = [
- "nb",
+ "nb 0.1.3",
  "void",
 ]
 
 [[package]]
 name = "nb"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1411551beb3c11dedfb0a90a0fa256b47d28b9ec2cdff34c25a2fa59e45dbdc"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.0.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "proc-macro2"

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2018"
 
 [dependencies]
 cortex-m = "0.7"
-embedded-hal = "0.2.3"
+embedded-hal = { version = "0.2.7", features = ["unproven"] }
 nb = "0.1.2"
 
 atsame70j19  = { version = "0.21.0", path = "../pac/atsame70j19", optional = true }

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -16,9 +16,9 @@ keywords = [
     "hal"
 ]
 license = "0BSD"
-repository = "https://github.com/michalfita/atsams-rust"
+repository = "https://github.com/atsams-rs/atsamx7x-rust"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortex-m = "0.7"

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -141,3 +141,5 @@ pub use atsamv71q21b as target_device;
 
 #[cfg(feature = "device-selected")]
 pub mod serial;
+#[cfg(feature = "device-selected")]
+pub mod watchdog;

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-pub use embedded_hal as hal;
+pub use embedded_hal as ehal;
 pub use nb;
 
 #[cfg(not(feature = "device-selected"))]

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-extern crate embedded_hal as hal;
-extern crate nb;
+pub use embedded_hal as hal;
+pub use nb;
 
 #[cfg(not(feature = "device-selected"))]
 compile_error!(

--- a/hal/src/serial.rs
+++ b/hal/src/serial.rs
@@ -1,4 +1,4 @@
-use crate::{hal, nb};
+use crate::{ehal, nb};
 
 // Smaller part have 3x UART & 2x USART
 use crate::target_device::{UART0, UART1, UART2, USART0, USART1};
@@ -108,7 +108,7 @@ pub enum Error {
     // omitted: other error variants
 }
 
-impl hal::serial::Write<u8> for Serial<UART0> {
+impl ehal::serial::Write<u8> for Serial<UART0> {
     type Error = Error;
 
     fn write(&mut self, word: u8) -> nb::Result<(), Error> {
@@ -120,7 +120,7 @@ impl hal::serial::Write<u8> for Serial<UART0> {
     }
 }
 
-impl hal::serial::Write<u8> for Serial<USART1> {
+impl ehal::serial::Write<u8> for Serial<USART1> {
     type Error = Error;
 
     fn write(&mut self, word: u8) -> nb::Result<(), Error> {
@@ -138,7 +138,7 @@ impl hal::serial::Write<u8> for Serial<USART1> {
     feature = "same70q20b",
     feature = "same70q21b",
 ))]
-impl hal::serial::Write<u8> for Serial<UART3> {
+impl ehal::serial::Write<u8> for Serial<UART3> {
     type Error = Error;
 
     fn write(&mut self, word: u8) -> nb::Result<(), Error> {

--- a/hal/src/serial.rs
+++ b/hal/src/serial.rs
@@ -1,3 +1,5 @@
+use crate::{hal, nb};
+
 // Smaller part have 3x UART & 2x USART
 use crate::target_device::{UART0, UART1, UART2, USART0, USART1};
 #[cfg(any(

--- a/hal/src/watchdog.rs
+++ b/hal/src/watchdog.rs
@@ -1,5 +1,5 @@
 //! Watchdog timer configuration.
-use crate::{hal, target_device};
+use crate::{ehal, target_device};
 
 pub struct Watchdog(target_device::WDT);
 
@@ -9,7 +9,7 @@ impl Watchdog {
     }
 }
 
-impl hal::watchdog::WatchdogDisable for Watchdog {
+impl ehal::watchdog::WatchdogDisable for Watchdog {
     fn disable(&mut self) {
         self.0.wdt_mr.write(|w| w.wddis().set_bit());
     }

--- a/hal/src/watchdog.rs
+++ b/hal/src/watchdog.rs
@@ -1,0 +1,16 @@
+//! Watchdog timer configuration.
+use crate::{hal, target_device};
+
+pub struct Watchdog(target_device::WDT);
+
+impl Watchdog {
+    pub fn new(wdt: target_device::WDT) -> Self {
+        Self(wdt)
+    }
+}
+
+impl hal::watchdog::WatchdogDisable for Watchdog {
+    fn disable(&mut self) {
+        self.0.wdt_mr.write(|w| w.wddis().set_bit());
+    }
+}


### PR DESCRIPTION
This PR implements `embedded_hal::watchdog::WatchdogDisable` from the unproven feature set. The watchdog is enabled on reset and resets the target if not fed after approximately 15 seconds.