### PR TITLE
PIO: open-drain/multi-driver support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [Integration](https://crates.io/crates/mcan-core) with the
 [`mcan`](https://crates.io/crates/mcan) crate.
 - Implementation of blocking::i2c::Transactional trait from [embedded-hal](https://crates.io/crates/embedded-hal) for TWI device.
+- PIO: open-drain/multi-driver support
 
 ### Changed
 

--- a/hal/src/pio/dynpin.rs
+++ b/hal/src/pio/dynpin.rs
@@ -73,6 +73,7 @@ pub enum DynPinMode {
     Reset,
     Peripheral(DynPeripheral),
     Output,
+    OpenDrain,
     Input,
 }
 

--- a/hal/src/pio/reg.rs
+++ b/hal/src/pio/reg.rs
@@ -23,6 +23,7 @@ pub(in crate::pio) trait RegisterInterface {
             DynPinMode::Reset => unimplemented!(),
             DynPinMode::Peripheral(a) => self.as_peripheral(a),
             DynPinMode::Output => self.as_output(),
+            DynPinMode::OpenDrain => self.as_opendrain(),
             DynPinMode::Input => self.as_input(),
         }
     }
@@ -65,6 +66,18 @@ pub(in crate::pio) trait RegisterInterface {
 
         // enable pin output
         self.reg().oer.write(|w| unsafe { w.bits(self.mask()) });
+    }
+
+    #[inline]
+    fn as_opendrain(&mut self) {
+        // take pin from peripheral
+        self.reg().per.write(|w| unsafe { w.bits(self.mask()) });
+
+        // Enable multidrive
+        self.reg().mder.write(|w| unsafe { w.bits(self.mask()) });
+
+        // disable pin output, driver should not be connected
+        self.reg().odr.write(|w| unsafe { w.bits(self.mask()) });
     }
 
     #[inline]


### PR DESCRIPTION
Copied from an internal Gitlab instance. By @axel-grepit:

> This patch implements the open drain ("multi-driver") mode with pull-up and pull-down for each pin.

> I could not find any information indicating that the modes are not supported for any specific pins and have as such followed the same patterns of implementation as for the other pin modes.

> Additionally, the `InputPin` and `OutputPin` traits are implemented for `OpenDrain` pins. This permits using crates like `onewire` to quickly implement software 1-wire support for Dallas-style sensors (ds18b20 for instance).

> WIP: InputPin/OutputPin needs additional testing before merging. Feel free to split the MR and commit the relevant OD-parts if that is needed before the relevant tests may be carried out.