### PR TITLE
USART: Remove mode check in `enter_mode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `Usart::enter_mode`: initial configuration of port as USART is now permitted.
+
 ## [v0.4.0] TBD
 
 ### Added

--- a/hal/src/serial/usart/mod.rs
+++ b/hal/src/serial/usart/mod.rs
@@ -387,11 +387,6 @@ impl<M: UsartMeta> Usart<M> {
         // successful as_*, meaning that we do not need to check for
         // support again.
 
-        if self.mode() == H::MODE {
-            // Already in the requested mode
-            return;
-        }
-
         self.disable();
 
         // Wipe current config and reset target mode.


### PR DESCRIPTION
This patch addresses issue https://github.com/atsams-rs/atsamx7x-rust/issues/27 wherein USART configuration fails if no other mode was selected prior to that. This is done by permitting the mode to be set multiple times, even if it is the same mode.

Initially, the USART is in the default USART mode but has not actually been configured. Therefore the `enter_mode` routine will exit early and skip configuration entirely unless care is taken and a dummy reconfiguration step is done before switching to USART.

The consequence of not performing this check is that the bus configuration will reset and possibly glitch momentarily if the same mode is setup twice, but that should not be done anyhow and has not been encouraged as far as I can tell.