### PR TITLE
Add warnings denial to github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: HAL
 on: [push, pull_request]
 
+env:
+  RUSTDOCFLAGS: -D warnings
+  RUSTFLAGS: -D warnings
+
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- (crate internal) Added `-D warnings` flags to workflow to help catch some documentation errors 
+
 ### Changed
 
 - The special-on-reset pins `PB4/5/6/7/12` are now completely unavailable, if the `reconfigurable-system-pins` feature is not enabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- (crate internal) Added `-D warnings` flags to workflow to help catch some documentation errors 
+- CI: `-D warnings` flags to cargo workflows.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- CI: `-D warnings` flags to cargo workflows.
+- CI: `-D warnings` flags to cargo workflows to catch documentation errors.
 
 ### Changed
 


### PR DESCRIPTION
Related to #47, I have found that denying warnings for `rustdoc` helps to catch some errors that prevent builds on docs.rs.

This does not resolve #47 though