### PR TITLE
Update `cortex-m-rt` version in examples to 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 - Remove `rust-toolchain.toml` and control MSRV from .github/workflow/ files instead.
+- Update `cortex-m-rt` version in examples to `0.7.3`.
 
 ### Removed
 

--- a/boards/atsame70_xpro/Cargo.lock
+++ b/boards/atsame70_xpro/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "cortex-m",
  "embedded-hal",
  "fugit",
+ "mcan-core",
  "nb 1.0.0",
  "paste",
  "rtic-monotonic",
@@ -126,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rt"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c433da385b720d5bb9f52362fa2782420798e68d40d67bfe4b0d992aba5dfe7"
+checksum = "ee84e813d593101b1723e13ec38b6ab6abbdbaaa4546553f5395ed274079ddb1"
 dependencies = [
  "cortex-m-rt-macros",
 ]
@@ -270,6 +271,15 @@ checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
+]
+
+[[package]]
+name = "mcan-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3dee4ff5269e2465cc856d37103cce916c1ef73b4377f006c963872e69f7ca"
+dependencies = [
+ "fugit",
 ]
 
 [[package]]

--- a/boards/atsamv71_xult/Cargo.lock
+++ b/boards/atsamv71_xult/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rt"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c433da385b720d5bb9f52362fa2782420798e68d40d67bfe4b0d992aba5dfe7"
+checksum = "ee84e813d593101b1723e13ec38b6ab6abbdbaaa4546553f5395ed274079ddb1"
 dependencies = [
  "cortex-m-rt-macros",
 ]


### PR DESCRIPTION
## Summary
Bumps the `cortex-m-rt` versions in the lockfiles in the examples to 0.7.3.

Due to the discovery in https://github.com/rust-embedded/cortex-m/discussions/469, it is not advisable to be using 0.7.1 or 0.7.2 of `cortex-m-rt` anymore.