### PR TITLE
Implemented Transactional for TWI (I²C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [Integration](https://crates.io/crates/mcan-core) with the
 [`mcan`](https://crates.io/crates/mcan) crate.
+- Implementation of blocking::i2c::Transactional trait from [embedded-hal](https://crates.io/crates/embedded-hal) for TWI device.
 
 ### Changed
 


### PR DESCRIPTION
Added implementation for the `embedded_hal::blocking::i2c::Transactional` trait for the TWI device.