### PR TITLE
Remove `rust-toolchain.toml` and control MSRV from CI instead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 env:
   RUSTDOCFLAGS: -D warnings
   RUSTFLAGS: -D warnings
+  MSRV: 1.63.0
 
 jobs:
   setup:
@@ -31,8 +32,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Specify toolchain
+        run: rustup override set $MSRV
       - name: Install Rust (thumbv7em)
-        run: rustup show
+        run: rustup target add thumbv7em-none-eabihf
       - name: Build HAL for ${{ matrix.pac }}
         run: cargo check --package atsamx7x-hal --features ${{ matrix.pac }},unproven
 
@@ -45,8 +48,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Specify toolchain
+        run: rustup override set $MSRV
       - name: Install Rust (thumbv7em)
-        run: rustup show
+        run: rustup target add thumbv7em-none-eabihf
       - name: Build HAL for ${{ matrix.features }}
         run: cargo check --package atsamx7x-hal --features ${{ matrix.features }},samv71q21b,unproven
 
@@ -59,8 +64,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Specify toolchain
+        run: rustup override set $MSRV
       - name: Install Rust (thumbv7em)
-        run: rustup show
+        run: rustup target add thumbv7em-none-eabihf
       - name: Build boards/${{ matrix.board }}/examples/*
         run: |
           cd boards/${{ matrix.board }}
@@ -72,8 +79,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Specify toolchain
+        run: rustup override set $MSRV
       - name: Install Rust (thumbv7em)
-        run: rustup show
+        run: rustup target add thumbv7em-none-eabihf
       - name: Lint HAL
         run: cargo clippy --package atsamx7x-hal --no-deps --features samv71q21b,unproven,reconfigurable-system-pins -- --deny warnings
 
@@ -86,8 +95,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Specify toolchain
+        run: rustup override set $MSRV
       - name: Install Rust (thumbv7em)
-        run: rustup show
+        run: rustup target add thumbv7em-none-eabihf
       - name: Lint boards/${{ matrix.board }}/examples/*
         run: |
           cd boards/${{ matrix.board }}
@@ -99,8 +110,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Specify toolchain
+        run: rustup override set $MSRV
       - name: Install Rust (thumbv7em)
-        run: rustup show
+        run: rustup target add thumbv7em-none-eabihf
       - name: Build HAL documentation
         run: cargo doc --package atsamx7x-hal --no-deps --features samv71q21b,unproven,reconfigurable-system-pins
       - name: Build HAL doc tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,8 @@ jobs:
         run: rustup override set $MSRV
       - name: Install Rust (thumbv7em)
         run: rustup target add thumbv7em-none-eabihf
+      - name: Install Clippy
+        run: rustup component add clippy
       - name: Lint HAL
         run: cargo clippy --package atsamx7x-hal --no-deps --features samv71q21b,unproven,reconfigurable-system-pins -- --deny warnings
 
@@ -99,6 +101,8 @@ jobs:
         run: rustup override set $MSRV
       - name: Install Rust (thumbv7em)
         run: rustup target add thumbv7em-none-eabihf
+      - name: Install Clippy
+        run: rustup component add clippy
       - name: Lint boards/${{ matrix.board }}/examples/*
         run: |
           cd boards/${{ matrix.board }}

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -3,14 +3,17 @@ on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
+  MSRV: 1.63.0
 
 jobs:
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Specify toolchain
+        run: rustup override set $MSRV
       - name: Install Rust (thumbv7em)
-        run: rustup show
+        run: rustup target add thumbv7em-none-eabihf
       - run: |
           set -xeu
           cargo fmt --package atsamx7x-hal -- --check

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -14,6 +14,8 @@ jobs:
         run: rustup override set $MSRV
       - name: Install Rust (thumbv7em)
         run: rustup target add thumbv7em-none-eabihf
+      - name: Install Rustfmt
+        run: rustup component add rustfmt
       - run: |
           set -xeu
           cargo fmt --package atsamx7x-hal -- --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Implementation of blocking::i2c::Transactional trait from [embedded-hal](https://crates.io/crates/embedded-hal) for TWI device.
 
 ### Changed
+- Remove `rust-toolchain.toml` and control MSRV from .github/workflow/ files instead.
 
 ### Removed
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,0 @@
-[toolchain]
-channel = "1.63.0"
-components = [ "rustfmt", "clippy" ]
-targets = [ "thumbv7em-none-eabihf", "x86_64-unknown-linux-gnu" ]
-profile = "minimal"


### PR DESCRIPTION
Resolves #57 

This was the simplest solution I could find. 
There's a repository called `actions-rs` that can be used for toolchain management in Github CI (among other things, I'm sure).
However, looking into that would take more time than I'm looking to spend right now.

We should also consider adding stable to the CI process as well. Currently we have some warnings that are emitted on stable that are not present on 1.63.0.