### PR TITLE
[Fixes #62] Remove re-exports to avoid warnings promoted to errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
     strategy:
       matrix:
         pac: ${{ fromJson(needs.setup.outputs.pac_matrix) }}
+    continue-on-error: true # we let this fail and carry on, but GH UI is poor not showing amber like other CIs
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: HAL
-on: [push]
+on: [push, pull_request]
 
 env:
   RUSTDOCFLAGS: -D warnings
@@ -8,6 +8,7 @@ env:
 
 jobs:
   setup:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -24,6 +25,7 @@ jobs:
       feature_matrix: ${{ steps.features.outputs.feature_matrix }}
 
   build:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     needs: setup
     runs-on: ubuntu-latest
     strategy:
@@ -40,6 +42,7 @@ jobs:
         run: cargo check --package atsamx7x-hal --features ${{ matrix.pac }},unproven
 
   build-latest:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     needs: setup
     runs-on: ubuntu-latest
     strategy:
@@ -59,6 +62,7 @@ jobs:
         run: cargo check --package atsamx7x-hal --features ${{ matrix.pac }},unproven
 
   build-features:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     needs: setup
     runs-on: ubuntu-latest
     strategy:
@@ -75,6 +79,7 @@ jobs:
         run: cargo check --package atsamx7x-hal --features ${{ matrix.features }},samv71q21b,unproven
 
   board-examples:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     needs: setup
     runs-on: ubuntu-latest
     strategy:
@@ -93,6 +98,7 @@ jobs:
           cargo check --examples
 
   clippy-hal:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -108,6 +114,7 @@ jobs:
         run: cargo clippy --package atsamx7x-hal --no-deps --features samv71q21b,unproven,reconfigurable-system-pins -- --deny warnings
 
   clippy-examples:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     needs: [setup, build, board-examples]
     runs-on: ubuntu-latest
     strategy:
@@ -128,6 +135,7 @@ jobs:
           cargo clippy --examples --no-deps -- --deny warnings
 
   docs:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,24 @@ jobs:
       - name: Build HAL for ${{ matrix.pac }}
         run: cargo check --package atsamx7x-hal --features ${{ matrix.pac }},unproven
 
+  build-latest:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pac: ${{ fromJson(needs.setup.outputs.pac_matrix) }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Update toolchain
+        run: rustup update
+      - name: Specify toolchain
+        run: rustup override set stable
+      - name: Install Rust (thumbv7em)
+        run: rustup target add thumbv7em-none-eabihf
+      - name: Build HAL for ${{ matrix.pac }}
+        run: cargo check --package atsamx7x-hal --features ${{ matrix.pac }},unproven
+
   build-features:
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: HAL
-on: [push, pull_request]
+on: [push]
 
 env:
   RUSTDOCFLAGS: -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Added
 
-- [Integration](https://crates.io/crates/mcan-core) with the
-[`mcan`](https://crates.io/crates/mcan) crate.
+- [Integration](https://crates.io/crates/mcan-core) with the [`mcan`](https://crates.io/crates/mcan) crate.
 - Implementation of blocking::i2c::Transactional trait from [embedded-hal](https://crates.io/crates/embedded-hal) for TWI device.
 
 ### Changed
@@ -14,6 +13,7 @@
 ### Removed
 
 ### Fixed
+- [#62] Remove ambiguous reexports from `src/serial/mod.rs`.
 
 ## [v0.4.2] 2022-11-06
 

--- a/hal/src/serial/mod.rs
+++ b/hal/src/serial/mod.rs
@@ -20,15 +20,11 @@ impl ExtBpsU32 for u32 {
 }
 
 pub mod uart;
-pub use uart::*;
 
 pub mod usart;
-pub use usart::*;
 
 pub mod twi;
 pub use twi::*;
 
 #[cfg(not(feature = "pins-64"))]
 pub mod spi;
-#[cfg(not(feature = "pins-64"))]
-pub use spi::*;

--- a/hal/src/serial/usart/uart.rs
+++ b/hal/src/serial/usart/uart.rs
@@ -14,7 +14,7 @@ use crate::ehal::{self, blocking};
 pub enum UartError {
     /// A frame's stop bit was read as zero.
     Framing,
-    /// Parity check of the recived frame failed.
+    /// Parity check of the received frame failed.
     Parity,
     /// A word was received before the previous word was read.
     Overrun,


### PR DESCRIPTION
## Purpose

My `rustc` 1.72.0 started to spit warnings at me, and CI fails on workflows with disabled minimum compiler version to be used (as 1.63.0 seems to be unaffected).

## Scope

* Easy fix: Remove reexports as I'm not a fan of them coming from C++ world prefer namespaces leaving import renames to the user.
* Add building with the latest compiler to catch errors that may break people with newer toolchain than MRV.
* Reduce the strain on CI and remove doubling jobs.

## Alternative

The alternative is to rename types to be more peripheral type specific. I have feeling at the moment we have mixture of both simple names in namespaces and specifically named peripherals despite being in namespaces.