### PR TITLE
Fix CI: source of PACs matrix + clippy satisfaction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
       - id: pacs
-        run: echo "::set-output name=pac_matrix::$(ls ./pac --indicator-style=none | grep atsam | cut -c 3- | jq -ncR '[inputs]')"
+        run: echo "::set-output name=pac_matrix::$(grep -o '^sam\w*' hal/Cargo.toml | uniq | jq -ncR '[inputs]')"
       - id: boards
         run: echo "::set-output name=board_matrix::$(ls ./boards --indicator-style=none | jq -ncR '[inputs]')"
       - id: features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Examples now build and link again
 - [#62] Remove ambiguous reexports from `src/serial/mod.rs`.
 - TWIHS: Fix issue with clock frequency calculation.
+- Fix CI
 
 ## [v0.4.2] 2022-11-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Examples now build and link again
 - [#62] Remove ambiguous reexports from `src/serial/mod.rs`.
 - TWIHS: Fix issue with clock frequency calculation.
-- Fix CI
+- Fix CI: source of PACs matrix + clippy satisfaction
 
 ## [v0.4.2] 2022-11-06
 

--- a/hal/src/afec.rs
+++ b/hal/src/afec.rs
@@ -20,7 +20,7 @@ This implementation presumes that VREFP is 3.3V.
 # use hal::efc::*;
 # use hal::afec::*;
 # use hal::fugit::RateExtU32;
-# let pac = hal::pac::Peripherals::take().unwrap();
+# let pac = unsafe{ hal::pac::Peripherals::steal() };
 # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
 
 let banka = BankA::new(pac.PIOA, &mut mck, &slck, BankConfiguration::default());

--- a/hal/src/clocks/mod.rs
+++ b/hal/src/clocks/mod.rs
@@ -28,7 +28,7 @@ For example, if we want to configure the [`MainClock`]:
 use atsamx7x_hal as hal;
 use hal::fugit::RateExtU32;
 
-let pac = hal::pac::Peripherals::take().unwrap();
+let pac = unsafe{hal::pac::Peripherals::steal()};
 let clocks = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into());
 let mainck = clocks
     .mainck
@@ -72,7 +72,7 @@ use hal::efc::{Efc, VddioLevel};
 use hal::fugit::RateExtU32;
 
 // configure the clock hierarchy
-let pac = hal::pac::Peripherals::take().unwrap();
+let pac = unsafe{hal::pac::Peripherals::steal()};
 let clocks = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into());
 let slck = clocks.slck.configure_external_normal();
 let mainck = clocks

--- a/hal/src/pio/bank.rs
+++ b/hal/src/pio/bank.rs
@@ -42,7 +42,7 @@ impl<B: PinBank> BankInterrupts<B> {
     /// # use hal::pio::*;
     /// # use hal::clocks::*;
     /// # use hal::efc::*;
-    /// # let pac = hal::pac::Peripherals::take().unwrap();
+    /// # let pac = unsafe{hal::pac::Peripherals::steal()};
     /// # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
     /// let mut banka = BankA::new(pac.PIOA, &mut mck, &slck, BankConfiguration::default());
     /// for pin in banka.interrupts.iter() {

--- a/hal/src/pio/mod.rs
+++ b/hal/src/pio/mod.rs
@@ -86,7 +86,7 @@ The below example configures [`Pin<PA11, Input>`] to trigger on
 # use hal::pio::*;
 # use hal::clocks::*;
 # use hal::efc::*;
-# let pac = hal::pac::Peripherals::take().unwrap();
+# let pac = unsafe{hal::pac::Peripherals::steal()};
 # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
 
 let banka = BankA::new(

--- a/hal/src/pio/reg.rs
+++ b/hal/src/pio/reg.rs
@@ -150,7 +150,7 @@ pub(in crate::pio) trait RegisterInterface {
     }
 
     fn set_interrupt(&mut self, cfg: Option<InterruptType>) {
-        if cfg == None {
+        if cfg.is_none() {
             // Disable pin interrupt
             //
             // XXX The peripheral clock is not disabled because it
@@ -191,7 +191,7 @@ pub(in crate::pio) trait RegisterInterface {
     }
 
     fn set_filter(&mut self, cfg: Option<InputFilter>) {
-        if cfg == None {
+        if cfg.is_none() {
             // disable the input filter
             self.reg().ifdr.write(|w| unsafe { w.bits(self.mask()) });
         } else {

--- a/hal/src/pwm.rs
+++ b/hal/src/pwm.rs
@@ -17,7 +17,7 @@ Refer to §51 for a full description of the PWM peripheral.
 # use hal::efc::*;
 # use hal::pwm::*;
 # use hal::fugit::RateExtU32;
-# let pac = hal::pac::Peripherals::take().unwrap();
+# let pac = unsafe{hal::pac::Peripherals::steal()};
 # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
 use hal::ehal::PwmPin;
 

--- a/hal/src/rtt.rs
+++ b/hal/src/rtt.rs
@@ -23,7 +23,7 @@ via [`Rtt::new_8192Hz`].
 # use hal::rtt::*;
 # use hal::fugit::RateExtU32;
 # use rtic_monotonic::*;
-# let pac = hal::pac::Peripherals::take().unwrap();
+# let pac = unsafe{hal::pac::Peripherals::steal()};
 # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
 
 let mono: Mono<100> = Rtt::new(pac.RTT, &slck, 100.Hz()).unwrap().into_monotonic();
@@ -37,7 +37,7 @@ or
 # use hal::rtt::*;
 # use hal::fugit::RateExtU32;
 # use rtic_monotonic::Monotonic;
-# let pac = hal::pac::Peripherals::take().unwrap();
+# let pac = unsafe{hal::pac::Peripherals::steal()};
 # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
 
 use hal::ehal::{blocking::delay::DelayMs, timer::{CountDown, Cancel}};
@@ -83,7 +83,7 @@ pub enum RttError {
     /// # use hal::efc::*;
     /// # use hal::rtt::*;
     /// # use hal::fugit::RateExtU32;
-    /// # let pac = hal::pac::Peripherals::take().unwrap();
+    /// # let pac = unsafe{hal::pac::Peripherals::steal()};
     /// # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
     /// let rtt: Rtt<100> = Rtt::new(pac.RTT, &slck, 100.Hz()).unwrap();
     /// ```

--- a/hal/src/serial/spi.rs
+++ b/hal/src/serial/spi.rs
@@ -211,12 +211,11 @@ impl SpiConfiguration {
 }
 
 /// Generates a default [`Spi`] configuration: test mode inactive.
-impl Default for SpiConfiguration{
+impl Default for SpiConfiguration {
     fn default() -> Self {
         SpiConfiguration { test_mode: false }
     }
 }
-
 
 /// SPI peripheral abstraction.
 pub struct Spi<M: SpiMeta> {
@@ -642,10 +641,7 @@ impl<'spi, M: SpiMeta> blocking::spi::Transactional<u8> for Client<'spi, M> {
 
     /// Execute the provided transactions, deasserting the select line
     /// after the last transmitted word.
-    fn exec(
-        &mut self,
-        operations: &mut [blocking::spi::Operation<u8>],
-    ) -> Result<(), Self::Error> {
+    fn exec(&mut self, operations: &mut [blocking::spi::Operation<u8>]) -> Result<(), Self::Error> {
         use blocking::spi::Operation;
 
         let len = operations.len();

--- a/hal/src/serial/twi.rs
+++ b/hal/src/serial/twi.rs
@@ -20,7 +20,7 @@ implemented.
 # use hal::efc::*;
 # use hal::serial::twi::*;
 # use hal::fugit::RateExtU32;
-# let pac = hal::pac::Peripherals::take().unwrap();
+# let pac = unsafe{hal::pac::Peripherals::steal()};
 # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
 let banka = BankA::new(pac.PIOA, &mut mck, &slck, BankConfiguration::default());
 
@@ -367,10 +367,10 @@ enum TransactionalState {
 impl<M: TwiMeta> blocking::i2c::Transactional for Twi<M> {
     type Error = TwiError;
 
-    fn exec<'a>(
+    fn exec(
         &mut self,
         address: u8,
-        operations: &mut [blocking::i2c::Operation<'a>],
+        operations: &mut [blocking::i2c::Operation],
     ) -> Result<(), Self::Error> {
         let mut state = TransactionalState::Uninitialized;
 

--- a/hal/src/serial/uart.rs
+++ b/hal/src/serial/uart.rs
@@ -26,7 +26,7 @@ Interrupt event management is handled by the [`event system`](crate::generics::e
 # use hal::serial::uart::*;
 # use hal::serial::ExtBpsU32;
 # use hal::fugit::{ExtU32, RateExtU32};
-# let pac = hal::pac::Peripherals::take().unwrap();
+# let pac = unsafe{hal::pac::Peripherals::steal()};
 let clocks = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into());
 let slck = clocks.slck.configure_external_normal();
 let mainck = clocks

--- a/hal/src/serial/usart/mod.rs
+++ b/hal/src/serial/usart/mod.rs
@@ -32,7 +32,7 @@ Mode support depends on what [`Pin`]s that are available for the
 # use hal::serial::usart::*;
 # use hal::serial::ExtBpsU32;
 # use hal::fugit::{ExtU32, RateExtU32};
-# let pac = hal::pac::Peripherals::take().unwrap();
+# let pac = unsafe{hal::pac::Peripherals::steal()};
 # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
 use hal::generics::events::EventHandler;
 use hal::ehal::serial::{Read, Write};

--- a/hal/src/serial/usart/spi.rs
+++ b/hal/src/serial/usart/spi.rs
@@ -227,9 +227,9 @@ impl<M: UsartMeta, R: SpiRole> ehal::spi::FullDuplex<u8> for Spi<M, R> {
 impl<M: UsartMeta, R: SpiRole> blocking::spi::Transactional<u8> for Spi<M, R> {
     type Error = SpiError;
 
-    fn exec<'a>(
+    fn exec(
         &mut self,
-        operations: &mut [blocking::spi::Operation<'a, u8>],
+        operations: &mut [blocking::spi::Operation<u8>],
     ) -> Result<(), Self::Error> {
         use blocking::spi::Operation;
 

--- a/hal/src/serial/usart/spi.rs
+++ b/hal/src/serial/usart/spi.rs
@@ -227,10 +227,7 @@ impl<M: UsartMeta, R: SpiRole> ehal::spi::FullDuplex<u8> for Spi<M, R> {
 impl<M: UsartMeta, R: SpiRole> blocking::spi::Transactional<u8> for Spi<M, R> {
     type Error = SpiError;
 
-    fn exec(
-        &mut self,
-        operations: &mut [blocking::spi::Operation<u8>],
-    ) -> Result<(), Self::Error> {
+    fn exec(&mut self, operations: &mut [blocking::spi::Operation<u8>]) -> Result<(), Self::Error> {
         use blocking::spi::Operation;
 
         for o in operations.iter_mut() {

--- a/hal/src/tc/generate.rs
+++ b/hal/src/tc/generate.rs
@@ -144,7 +144,7 @@ where
         // integer.
         //
         // Safe: driver was consumed in Channel::chain.
-        let mut driver = unsafe { Channel::<M, J, _>::new::<Generate<C, DRIVER_FREQ_HZ>>() };
+        let mut driver = unsafe { Channel::<M, J, _>::new() };
         // The 16-bit counter is incremented only at each positive
         // input clock edge. When chaining channels, this then results
         // in a static /2 prescaler. Refer to §50.6.2.

--- a/hal/src/tc/mod.rs
+++ b/hal/src/tc/mod.rs
@@ -22,7 +22,7 @@ Refer to §50 for a full description on the capabilities offered by a [`Tc`].
 # use hal::efc::*;
 # use hal::tc::*;
 # use hal::fugit::ExtU32;
-# let pac = hal::pac::Peripherals::take().unwrap();
+# let pac = unsafe{hal::pac::Peripherals::steal()};
 # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
 let banka = hal::pio::BankA::new(
     pac.PIOA,
@@ -54,7 +54,7 @@ counter.sample_freq(100.millis());
 # use hal::clocks::*;
 # use hal::efc::*;
 # use hal::tc::*;
-# let pac = hal::pac::Peripherals::take().unwrap();
+# let pac = unsafe{hal::pac::Peripherals::steal()};
 # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
 let tc = Tc::new_tc0(pac.TC0, &mut mck);
 let driver = tc
@@ -80,7 +80,7 @@ let mono: Monotonic<Tc0, Ch1, Channel<Tc0, Ch0, Generate<HostClock, 12_000_000>>
 # use hal::clocks::*;
 # use hal::efc::*;
 # use hal::tc::*;
-# let pac = hal::pac::Peripherals::take().unwrap();
+# let pac = unsafe{hal::pac::Peripherals::steal()};
 # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
 let tc = Tc::new_tc0(pac.TC0, &mut mck);
 let driver = tc
@@ -410,7 +410,7 @@ pub enum TcError {
     /// # use hal::clocks::*;
     /// # use hal::efc::*;
     /// # use hal::tc::*;
-    /// # let pac = hal::pac::Peripherals::take().unwrap();
+    /// # let pac = unsafe{hal::pac::Peripherals::steal()};
     /// # let (slck, mut mck) = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into()).por_state(&mut Efc::new(pac.EFC, VddioLevel::V3));
     /// let tc = Tc::new_tc0(pac.TC0, &mut mck);
     /// let ch = tc.channel_0.generate::<15_000_000>(&mck).unwrap();
@@ -452,7 +452,7 @@ impl<M: TcMeta, I: ChannelId, S: ChannelState> Channel<M, I, S> {
     ///
     /// A [`Channel`] can modify hardware, but can be created without
     /// consuming a corresponding singleton.
-    const unsafe fn new<So: ChannelState>() -> Self {
+    const unsafe fn new() -> Self {
         Self {
             _meta: PhantomData,
             _id: PhantomData,
@@ -601,9 +601,9 @@ impl<M: TcMeta> Tc<M> {
         // Safe: the TC block has been consumed.
         let mut tc = Self {
             _meta: PhantomData,
-            channel_0: unsafe { Channel::new::<Inactive>() },
-            channel_1: unsafe { Channel::new::<Inactive>() },
-            channel_2: unsafe { Channel::new::<Inactive>() },
+            channel_0: unsafe { Channel::new() },
+            channel_1: unsafe { Channel::new() },
+            channel_2: unsafe { Channel::new() },
         };
 
         // Ensure channels are disabled.

--- a/hal/src/usb.rs
+++ b/hal/src/usb.rs
@@ -16,7 +16,7 @@ extensively tested, and should be considered unstable at the moment.
 # use hal::efc::*;
 # use hal::usb::*;
 # use hal::fugit::RateExtU32;
-# let pac = hal::pac::Peripherals::take().unwrap();
+# let pac = unsafe{hal::pac::Peripherals::steal()};
 # let clocks = Tokens::new((pac.PMC, pac.SUPC, pac.UTMI), &pac.WDT.into());
 # let slck = clocks.slck.configure_external_normal();
 # let mainck = clocks
@@ -108,7 +108,7 @@ impl Endpoints {
     fn find_free_endpoint(&self) -> UsbResult<usize> {
         // start with 1 because 0 is reserved for Control
         for idx in 1..NUM_ENDPOINTS {
-            if self.ep_config[idx] == None {
+            if self.ep_config[idx].is_none() {
                 return Ok(idx);
             }
         }
@@ -124,7 +124,7 @@ impl Endpoints {
         max_packet_size: u16,
         _interval: u8,
     ) -> UsbResult<EndpointAddress> {
-        if idx != 0 && self.ep_config[idx] != None {
+        if idx != 0 && self.ep_config[idx].is_some() {
             return Err(UsbError::EndpointOverflow);
         }
 
@@ -222,7 +222,7 @@ impl Inner {
     fn write_fifo(&self, ep: usize, buf: &[u8]) {
         unsafe {
             core::ptr::copy_nonoverlapping(
-                buf.as_ptr() as *const u8,
+                buf.as_ptr(),
                 self.fifo_addr(ep) as *mut u8,
                 buf.len(),
             );
@@ -235,7 +235,7 @@ impl Inner {
         unsafe {
             core::ptr::copy_nonoverlapping(
                 self.fifo_addr(ep) as *const u8,
-                buf.as_mut_ptr() as *mut u8,
+                buf.as_mut_ptr(),
                 buf.len(),
             );
         }
@@ -431,7 +431,7 @@ impl Inner {
         const DEVISR_PEPS_MASK: u32 = 0x3ff000;
         const DEVISR_PEPS_OFFSET: u8 = 12;
         for ep in BitIter::from((dev_isr.bits() & DEVISR_PEPS_MASK) >> DEVISR_PEPS_OFFSET) {
-            let sr = self.reg().deveptisr_ctrl_mode()[ep as usize].read();
+            let sr = self.reg().deveptisr_ctrl_mode()[ep].read();
 
             // SETUP packet?
             if sr.rxstpi().bit_is_set() {

--- a/hal/src/usb.rs
+++ b/hal/src/usb.rs
@@ -221,11 +221,7 @@ impl Inner {
     #[inline(always)]
     fn write_fifo(&self, ep: usize, buf: &[u8]) {
         unsafe {
-            core::ptr::copy_nonoverlapping(
-                buf.as_ptr(),
-                self.fifo_addr(ep) as *mut u8,
-                buf.len(),
-            );
+            core::ptr::copy_nonoverlapping(buf.as_ptr(), self.fifo_addr(ep) as *mut u8, buf.len());
         }
     }
 


### PR DESCRIPTION
The CI was broken due to the pac folder being removed.
This fix extracts the pac features from `hal/Cargo.toml` instead.