### PR TITLE
Added neovim rust-analyzer config file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IDE/Editors specific stuff and junk
 .vscode/
+rust-analyzer.json
 
 # Build artifacts
 target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [Integration](https://crates.io/crates/mcan-core) with the [`mcan`](https://crates.io/crates/mcan) crate.
 - Implementation of blocking::i2c::Transactional trait from [embedded-hal](https://crates.io/crates/embedded-hal) for TWI device.
 - Support for `critical-section` feature, falling down to PAC optional dependency.
+- Add `rust-analyzer.json` used by Neovim plugin `rustaceanvim` to `.gitignore`.
 
 ### Changed
 - Remove `rust-toolchain.toml` and control MSRV from `.github/workflow/` files instead.


### PR DESCRIPTION
The rust-analyzer.json file is the default file for configuring rust-analyzer on a per project basis for [rustaceanvim](https://github.com/mrcjkb/rustaceanvim). Added it to the `.gitignore` as it is similar in function to the `.vscode` directory. Did not see it fit to add to the changelog as this does not change the hal in in any way and only has to do with not getting config files included in the repo.