### PR TITLE
Use default USB LangID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- `usb_serial_echo` example will use LangID::EN_US .
+
 ## [v0.4.6] 2025-03-31
 
 ### Changed

--- a/boards/atsame70_xpro/examples/usb_serial_echo.rs
+++ b/boards/atsame70_xpro/examples/usb_serial_echo.rs
@@ -55,7 +55,7 @@ mod app {
             ctx.local.usb_alloc.as_ref().unwrap(),
             UsbVidPid(0xdead, 0xbeef),
         )
-        .strings(&[StringDescriptors::new(LangID::EN)
+        .strings(&[StringDescriptors::default()
             .manufacturer("ATSAMx7x HAL Contributors")
             .product("Serial port echo")
             .serial_number("N/A")])

--- a/boards/atsamv71_xult/examples/usb_serial_echo.rs
+++ b/boards/atsamv71_xult/examples/usb_serial_echo.rs
@@ -55,7 +55,7 @@ mod app {
             ctx.local.usb_alloc.as_ref().unwrap(),
             UsbVidPid(0xdead, 0xbeef),
         )
-        .strings(&[StringDescriptors::new(LangID::EN)
+        .strings(&[StringDescriptors::default()
             .manufacturer("ATSAMx7x HAL Contributors")
             .product("Serial port echo")
             .serial_number("N/A")])


### PR DESCRIPTION
Use default language-identifier of LangID::EN_US instead of LangID::EN .
This is required for Windows.