### PR TITLE
Fix incorrect Host Clock Controller's `configure()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+- Host Clock Controller needs to also use the divisor when dividing the clock down to MCK.
+    
+### Changed
+- Minor comment updates.
+
 ## [v0.4.6] 2025-03-31
 
 ### Changed

--- a/hal/src/clocks/hcc.rs
+++ b/hal/src/clocks/hcc.rs
@@ -121,7 +121,7 @@ impl HostClockController {
     ) -> Result<(ProcessorClock, HostClock), ClockError> {
         // Ensure we use the correct amount of wait states for flash
         // access for the new HCLK frequency.
-        efc.set_wait_states(source.freq().convert() / (pres as u32))?;
+        efc.set_wait_states(source.freq().convert() / (pres as u32) / (div as u32))?;
 
         let freq = source.freq();
 

--- a/hal/src/clocks/mainck.rs
+++ b/hal/src/clocks/mainck.rs
@@ -67,7 +67,7 @@ impl Token<MainClock<InternalRC>> {
         }
 
         // Enable the external oscillator and wait for it to
-        // stabilize.
+        // stabilize. (§31.17; step 2)
         self.pmc().ckgr_mor().modify(|_, w| {
             w.key().passwd();
             w.moscxten().set_bit();
@@ -78,7 +78,7 @@ impl Token<MainClock<InternalRC>> {
         });
         while self.pmc().sr().read().moscxts().bit_is_clear() {}
 
-        // Switch over to the main oscillator.
+        // Switch over to the main oscillator. (§31.17; step 3 & 4)
         self.pmc().ckgr_mor().modify(|_, w| {
             w.key().passwd();
             w.moscsel().set_bit();


### PR DESCRIPTION
The `HostClockController` should use both `pres` & `div` when determining the EFC wait state.

Like this:
`efc.set_wait_states(source.freq().convert() / (pres as u32) / (div as u32))?;`

Also, minor comment updates.
