### PR TITLE
The Iterator next() function currently loops through each pin. This i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## [Unreleased]
 
+
 ### Added
 - Added `build.rs` to check if memory.x changed
+
+### Changed
+- `pio::bank::BankInterruptsIter::next`: increase performance by extracting irq index via Rust built-ins.
+
+### Fixed
+- Fixed an elided lifetime warning in spi.rs
 
 ## [v0.4.6] 2025-03-31
 

--- a/hal/src/pio/bank.rs
+++ b/hal/src/pio/bank.rs
@@ -80,7 +80,6 @@ impl<B: PinBank> BankInterrupts<B> {
 pub struct BankInterruptsIter<B: PinBank> {
     bank: PhantomData<B>,
     irq: u32,
-    idx: u8,
 }
 
 impl<B: PinBank> BankInterruptsIter<B> {
@@ -89,7 +88,6 @@ impl<B: PinBank> BankInterruptsIter<B> {
         Self {
             bank: PhantomData,
             irq,
-            idx: 0,
         }
     }
 }
@@ -103,25 +101,17 @@ impl<B: PinBank> Iterator for BankInterruptsIter<B> {
 
     /// Returns the next pin number in this [`PinBank`] that had a
     /// pending interrupt.
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        match self.idx {
-            32.. => {
-                // We have iterated over all pins: nothing more to do.
-                None
-            }
-            idx if self.irq & (1 << idx) != 0 => {
-                // Pin number `idx` had a pending interrupt.
-                let pin = self.idx;
-                self.idx += 1;
-                Some(pin)
-            }
-            _ => {
-                // Pin number `idx` did not have a pending interrupt:
-                // advance to the next pin.
-                self.idx += 1;
-                self.next()
-            }
+        if self.irq == 0 {
+            return None;
         }
+
+        // Extract index of pending irq and clear bit.
+        let bit_index = self.irq.trailing_zeros() as u8;
+        self.irq &= self.irq - 1;
+
+        Some(bit_index)
     }
 }
 


### PR DESCRIPTION
The Iterator next() function currently loops through each pin. This is highly inefficient to do inside an ISR, where it's commonly, and likely, used.

Use a Rust built-in intrinsic to optimize this.

Timing tests on an o-scope show this to be ~ 50% speedup.